### PR TITLE
Added dependencies to build script

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -1,1 +1,5 @@
 pip install gunicorn=='19.7.1'
+pip install django=='4.1.5'
+pip install dj-database-url
+pip install psycopg2-binary
+pip install 'whitenoise[brotli]'


### PR DESCRIPTION
We're still getting failures on Render deploys. Adding missing dependencies to build script as potential fix