### PR TITLE
Added workaround for whitenoise warning

### DIFF
--- a/mysite/settings.py
+++ b/mysite/settings.py
@@ -134,7 +134,7 @@ if not DEBUG:
 
     # Turn on WhiteNoise storage backend that takes care of compressing static files
     # and creating unique names for each version so they can safely be cached forever.
-    STATICFILES_STORAGE = 'whitenoise.storage.CompressedManifestStaticFilesStorage'
+    STATICFILES_STORAGE = 'whitenoise.storage.CompressedStaticFilesStorage'
 
 # Default primary key field type
 # https://docs.djangoproject.com/en/4.1/ref/settings/#default-auto-field


### PR DESCRIPTION
There's a 500 error on livesite so a workaround was added as a workaround. This issue is caused by whitenoise package