### PR TITLE
Updated build script and reset STATICFILES_STORAGE

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -1,5 +1,8 @@
-pip install gunicorn=='19.7.1'
-pip install django=='4.1.5'
-pip install dj-database-url
-pip install psycopg2-binary
-pip install 'whitenoise[brotli]'
+#!/usr/bin/env bash
+# exit on error
+set -o errexit
+
+poetry install
+
+python manage.py collectstatic --no-input
+python manage.py migrate

--- a/mysite/settings.py
+++ b/mysite/settings.py
@@ -134,7 +134,7 @@ if not DEBUG:
 
     # Turn on WhiteNoise storage backend that takes care of compressing static files
     # and creating unique names for each version so they can safely be cached forever.
-    STATICFILES_STORAGE = 'whitenoise.storage.CompressedStaticFilesStorage'
+    STATICFILES_STORAGE = 'whitenoise.storage.CompressedManifestStaticFilesStorage'
 
 # Default primary key field type
 # https://docs.djangoproject.com/en/4.1/ref/settings/#default-auto-field


### PR DESCRIPTION
Reconfigured build script to use poetry to install dependencies instead of individual pip installs. This will be a more optimal way to do this on Render deploys